### PR TITLE
coq-8.18 port

### DIFF
--- a/coq-switch.opam
+++ b/coq-switch.opam
@@ -12,8 +12,8 @@ install: [
   [make "install"]
 ]
 depends: [
-  "coq" {>= "8.13.0"}
-  "coq-metacoq-template" {>= "1.0~beta2+8.13"}
+  "coq" {>= "8.18.0"}
+  "coq-metacoq-template" {>= "1.2.1+8.18"}
 ]
 tags: [
   "category:Miscellaneous/Coq Extensions"

--- a/demo.v
+++ b/demo.v
@@ -13,9 +13,9 @@ Section NatExample.
 
 MetaCoq Run
       (mkSwitch nat
-                beq_nat
-                [(0,"Love") ; (10,"Ten") ; (20, "twenty")]
-                "Ex1_Choices" "ex1_select"
+                Nat.eqb
+                [(0,"Love"%bs) ; (10,"Ten"%bs) ; (20, "twenty"%bs)]
+                "Ex1_Choices"%bs "ex1_select"%bs
       ).
 
   Print Ex1_Choices.
@@ -43,18 +43,18 @@ Section StringExample.
   Infix "->" := pair.
 
   MetaCoq Run
-      (mkSwitch string string_beq [
-                  "love" -> "SLove" ;
-                "ten" -> "STen"  ;
-                "twenty" -> "STwenty"
-                ] "Ex2_Choices" "ex2_select"
+      (mkSwitch String.string string_beq [
+                  "love"%string   -> "SLove"%bs ;
+                  "ten"%string    -> "STen"%bs  ;
+                  "twenty"%string -> "STwenty"%bs
+                ] "Ex2_Choices"%bs "ex2_select"%bs
       ).
 
   Print Ex2_Choices.
   Print ex2_select.
 
 
-  Definition Ex2 (s:string) : nat :=
+  Definition Ex2 (s:String.string) : nat :=
     match ex2_select s with
     | Some SLove => 100
     | Some STen => 110

--- a/demo.v
+++ b/demo.v
@@ -6,6 +6,7 @@ Require Import Coq.Lists.List.
 Require Import MetaCoq.Template.All.
 
 Import ListNotations.
+Open Scope string_scope.
 
 Section NatExample.
 
@@ -44,9 +45,9 @@ Section StringExample.
 
   MetaCoq Run
       (mkSwitch String.string string_beq [
-                  "love"%string   -> "SLove" ;
-                  "ten"%string    -> "STen"  ;
-                  "twenty"%string -> "STwenty"
+                  "love"   -> "SLove" ;
+                  "ten"    -> "STen"  ;
+                  "twenty" -> "STwenty"
                 ] "Ex2_Choices" "ex2_select"
       ).
 

--- a/demo.v
+++ b/demo.v
@@ -14,8 +14,8 @@ Section NatExample.
 MetaCoq Run
       (mkSwitch nat
                 Nat.eqb
-                [(0,"Love"%bs) ; (10,"Ten"%bs) ; (20, "twenty"%bs)]
-                "Ex1_Choices"%bs "ex1_select"%bs
+                [(0,"Love") ; (10,"Ten") ; (20, "twenty")]
+                "Ex1_Choices" "ex1_select"
       ).
 
   Print Ex1_Choices.
@@ -44,10 +44,10 @@ Section StringExample.
 
   MetaCoq Run
       (mkSwitch String.string string_beq [
-                  "love"%string   -> "SLove"%bs ;
-                  "ten"%string    -> "STen"%bs  ;
-                  "twenty"%string -> "STwenty"%bs
-                ] "Ex2_Choices"%bs "ex2_select"%bs
+                  "love"%string   -> "SLove" ;
+                  "ten"%string    -> "STen"  ;
+                  "twenty"%string -> "STwenty"
+                ] "Ex2_Choices" "ex2_select"
       ).
 
   Print Ex2_Choices.

--- a/theories/Switch.v
+++ b/theories/Switch.v
@@ -1,11 +1,8 @@
-Require Import Coq.Strings.String.
 Require Import Coq.Lists.List.
 Require Import MetaCoq.Template.All.
 
-Import MonadNotation.
 Import ListNotations.
-
-Open Scope string_scope.
+Import MCMonadNotation.
 
 Definition rname (s:string) := {| binder_name := nNamed s; binder_relevance := Relevant |}.
 
@@ -18,24 +15,24 @@ Fixpoint mkSwitchCases
   let ind_0 n := {| inductive_mind := n; inductive_ind := 0 |} in
   let T_i := ind_0 type_name in
 
-  let bool_i := ind_0 (MPfile ["Datatypes"; "Init"; "Coq"], "bool") in
-  let opt_i := ind_0 (MPfile ["Datatypes"; "Init"; "Coq"], "option") in
+  let bool_i := ind_0 (MPfile ["Datatypes"%bs; "Init"%bs ; "Coq"%bs], "bool"%bs) in
+  let opt_i := ind_0 (MPfile ["Datatypes"%bs; "Init"%bs; "Coq"%bs], "option"%bs) in
   match choices_t with
   | [] => tApp (tConstruct opt_i 1 []) [tInd T_i []]
   | (x::xs) => tCase
                (* # of parameters *)
-               ((bool_i, 0), Relevant)
+               (mk_case_info bool_i 0 Relevant)
 
                (* type info *)
-               (tLambda (rname "b") (tInd bool_i []) (tApp (tInd opt_i []) [tInd T_i []]))
+               (mk_predicate [] [] [mkBindAnn nAnon Relevant] (tApp (tInd opt_i []) [tInd T_i []]))
 
                (* discriminee *)
                (tApp P_t [tRel 0; x])
 
                (* branches *)
                [
-                 (0, tApp (tConstruct opt_i 0 []) [tInd T_i []; tConstruct T_i n []]) ;
-               (0, mkSwitchCases type_name A_t P_t xs (S n))
+                 mk_branch [] (tApp (tConstruct opt_i 0 []) [tInd T_i []; tConstruct T_i n []]);
+                 mk_branch [] (mkSwitchCases type_name A_t P_t xs (S n))
                ]
   end.
 
@@ -65,12 +62,12 @@ Definition mkSwitch
           mind_entry_private   := None (* or (Some false)? *)
         |} in
     mp <- tmCurrentModPath tt ;;
-    ind_t <- tmMkInductive ind ;;
+    ind_t <- tmMkInductive false ind ;;
     T <- tmUnquoteTyped Type (tInd {| inductive_mind := (mp, type_name); inductive_ind := 0 |} []) ;;
     A_t <- tmQuote A ;;
     P_t <- tmQuote P ;;
     choices_t <- monad_map (fun x => tmQuote (fst x)) choices ;;
-    let body_t := tLambda (rname "x") A_t (mkSwitchCases (mp, type_name) A_t P_t choices_t 0) in
+    let body_t := tLambda (rname "x"%bs) A_t (mkSwitchCases (mp, type_name) A_t P_t choices_t 0) in
     body <- tmUnquoteTyped (A -> option T) body_t ;;
     def_t <- tmDefinition def_name body ;;
     tmReturn tt.

--- a/theories/Switch.v
+++ b/theories/Switch.v
@@ -4,6 +4,8 @@ Require Import MetaCoq.Template.All.
 Import ListNotations.
 Import MCMonadNotation.
 
+Open Scope bs_scope.
+
 Definition rname (s:string) := {| binder_name := nNamed s; binder_relevance := Relevant |}.
 
 Fixpoint mkSwitchCases
@@ -15,8 +17,8 @@ Fixpoint mkSwitchCases
   let ind_0 n := {| inductive_mind := n; inductive_ind := 0 |} in
   let T_i := ind_0 type_name in
 
-  let bool_i := ind_0 (MPfile ["Datatypes"%bs; "Init"%bs ; "Coq"%bs], "bool"%bs) in
-  let opt_i := ind_0 (MPfile ["Datatypes"%bs; "Init"%bs; "Coq"%bs], "option"%bs) in
+  let bool_i := ind_0 (MPfile ["Datatypes"; "Init" ; "Coq"], "bool") in
+  let opt_i := ind_0 (MPfile ["Datatypes"; "Init"; "Coq"], "option") in
   match choices_t with
   | [] => tApp (tConstruct opt_i 1 []) [tInd T_i []]
   | (x::xs) => tCase
@@ -67,7 +69,7 @@ Definition mkSwitch
     A_t <- tmQuote A ;;
     P_t <- tmQuote P ;;
     choices_t <- monad_map (fun x => tmQuote (fst x)) choices ;;
-    let body_t := tLambda (rname "x"%bs) A_t (mkSwitchCases (mp, type_name) A_t P_t choices_t 0) in
+    let body_t := tLambda (rname "x") A_t (mkSwitchCases (mp, type_name) A_t P_t choices_t 0) in
     body <- tmUnquoteTyped (A -> option T) body_t ;;
     def_t <- tmDefinition def_name body ;;
     tmReturn tt.


### PR DESCRIPTION
### Ported to work with Coq v8.18 and MetaCoq v1.2.1

Some notes on the changes:

* Latest versions of MetaCoq use different representation of strings
  * Namely, byte strings instead of default Coq string
  * This is due to performance considerations
* Latest versions of MetaCoq use some new record types in term representation
  * Examples: `case_info`, `predicate`, `branch`
* `tmMkInductive` now accepts addtional boolean argument
  * this is somehow related to inferencing of universes (?)  